### PR TITLE
Typo at https://docs.andronix.app/software/browsers

### DIFF
--- a/software/browsers.md
+++ b/software/browsers.md
@@ -19,7 +19,7 @@ If you are having any **armv7 based device** browsers might fail to work due to 
 ### Ubuntu / Ubuntu 20 / Debian / Kali Linux 
 
 ```text
-apt install firefox-esr -y
+apt install firefox -y
 ```
 
 ### Arch / Manjaro 


### PR DESCRIPTION
In docs.andronix.app change apt install firefox-esr -y to apt install firefox -y